### PR TITLE
Upgrading version argument. Added ability to set version through the sourcing command

### DIFF
--- a/activate.bash
+++ b/activate.bash
@@ -1,13 +1,18 @@
 ### (Don't edit below, unless you are a maintener of this package)
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Specify where node should be installed (default is 'node' folder -- probably keep it that way unless you have a good reason)
 LOCAL_NODE_INSTALL_DIRECTORY="$SCRIPT_DIR/node"
 
-# Retrieve node version to be installed/activated
-VERSION_FILE="$SCRIPT_DIR/version.bash";
-source $VERSION_FILE
+# Retrieve node version to be installed/activated (either from command line arguments, or version file)
+if [ -z "$1" ]
+then
+  # no command line argument, retrieve version from version file
+  VERSION_FILE="$SCRIPT_DIR/version.bash";
+  source $VERSION_FILE
+else
+  VERSION="$1"
+fi
 
 # 1. Make sure desired version is installed (install it, if not)
 $SCRIPT_DIR/install.sh $LOCAL_NODE_INSTALL_DIRECTORY $VERSION

--- a/version.bash
+++ b/version.bash
@@ -1,4 +1,4 @@
 # Specify desired node version (be as specific as possible, i.e. use the vxx.xx.xx format)
 # Navigate to https://nodejs.org/en/ to see the latest LTS (Long Term Support) & 'Current' versions
 # NOTE: Do not delete this file or rename the below variable (as it is referenced in ./activate.bash)
-VERSION="v16.13.2"
+VERSION="v16.14.0"


### PR DESCRIPTION
Realized this feature would be nice so that when setting up a project's unique `activate.bash` file, it could be set up like:

```bash
source ./local-node-install/activate.bash 16.14.0
```

instead of 
```bash
source ./local-node-install/activate.bash 
```
and relying on changing the internal version.bash file.

--------

Still need to:

- [ ] Edit readme
- [ ] Edit comments in version file