### PR TITLE
bump to node v18

### DIFF
--- a/version.bash
+++ b/version.bash
@@ -1,4 +1,4 @@
 # Specify desired node version (be as specific as possible, i.e. use the vxx.xx.xx format)
 # Navigate to https://nodejs.org/en/ to see the latest LTS (Long Term Support) & 'Current' versions
 # NOTE: Do not delete this file or rename the below variable (as it is referenced in ./activate.bash)
-VERSION="v16.13.2"
+VERSION="v18.12.1"


### PR DESCRIPTION
dunno if you're going to want to merge this, but i figured i should at least create the PR.  not sure how i ran https://github.com/mitmedialab/gi-watchtower/pull/2 locally without issue, but it died on gi.media because it relied on `utils.parseArgs`, which isn't in node v16.